### PR TITLE
production.rbを修正

### DIFF
--- a/backend/config/environments/production.rb
+++ b/backend/config/environments/production.rb
@@ -90,6 +90,11 @@ Rails.application.configure do
   # Renderからのリクエストを認証
   config.hosts << "cat-food-app.onrender.com"
 
+  #URLのデフォのホスト名の設定(Mailerのメール内URL生成などで機能する)
+  Rails.application.routes.default_url_options = {
+    host: 'cat-food-app.onrender.com'
+  }
+
   # メール用の設定
   config.action_mailer.default_options = { from: ENV['EMAIL_ADDRESS'] }
   config.action_mailer.default_url_options = { host: 'www.nekomanmafood.com', protocol: 'https' }


### PR DESCRIPTION
Rails.application.routes.default_url_optionsを追加。
この設定が無いと、自動的に生成されるurl（メーラーのリダイレクト用urlなど）が機能しない。